### PR TITLE
Command reuse bug

### DIFF
--- a/lib/DBIx/Class/Schema/PopulateMore/Command.pm
+++ b/lib/DBIx/Class/Schema/PopulateMore/Command.pm
@@ -234,7 +234,7 @@ sub execute
 
     foreach my $definition ($self->definitions)
     {
-        my ($source, $info) = each %$definition;
+        my ($source => $info) = %$definition;
         my @fields = $self->coerce_to_array($info->{fields});
         
         my $data = $self

--- a/t/01-schema.t
+++ b/t/01-schema.t
@@ -1,7 +1,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 40;
+use Test::More tests => 43;
 use DBIx::Class::Schema::PopulateMore::Test::Schema;
 
 ok my $schema = DBIx::Class::Schema::PopulateMore::Test::Schema->connect_and_setup
@@ -201,6 +201,14 @@ ok my $joe = $schema->resultset('Person')->search({name=>'joe'})->first,
   => 'Got a Person';
 
 is $joe->age, 19, 'Joe is 19';
+
+ok $joe->delete, 'Delete Joe';
+
+ok my %index2_again = $schema->populate_more($extra)
+  => 'Successful populated same data again.';
+
+ok my $joe_again = $schema->resultset('Person')->search({name=>'joe'})->first,
+  => 'Got a Person again';
 
 ok my %index3 = $schema->populate_more(
         Gender => {


### PR DESCRIPTION
Hello.

We should not use `each` here since it leaves `%$definition` not reseted. Using this again will result in getting `(undef, undef)`.
