### PR TITLE
switch from Moose to Moo

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,10 @@ use warnings FATAL => 'all';
 use inc::Module::Install;
 
 requires 'parent' => '0.224';
-requires 'Moo' => '1.004002';
+requires 'Moo' => '1.004006';
+requires 'MooX::HandlesVia' => '0.001005';
+requires 'Scalar::Util' => '1.35';
+requires 'Type::Tiny' => '0.042';
 requires 'DateTimeX::Easy' => '0.089';
 requires 'List::MoreUtils' => '0.30';
 requires 'Module::Pluggable' => '3.9';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ use warnings FATAL => 'all';
 use inc::Module::Install;
 
 requires 'parent' => '0.224';
-requires 'Moose' => '1.24';
+requires 'Moo' => '1.004002';
 requires 'DateTimeX::Easy' => '0.089';
 requires 'List::MoreUtils' => '0.30';
 requires 'Module::Pluggable' => '3.9';

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,7 +9,6 @@ requires 'Moo' => '1.004002';
 requires 'DateTimeX::Easy' => '0.089';
 requires 'List::MoreUtils' => '0.30';
 requires 'Module::Pluggable' => '3.9';
-requires 'Data::Visitor' => '0.27';
 
 test_requires 'DBIx::Class' => '0.08127';
 test_requires 'DateTime::Format::SQLite' => '0.11'; ## needed by DBIC for datetime in/deflators

--- a/lib/DBIx/Class/Schema/PopulateMore/Inflator.pm
+++ b/lib/DBIx/Class/Schema/PopulateMore/Inflator.pm
@@ -1,6 +1,6 @@
 package DBIx::Class::Schema::PopulateMore::Inflator;
 
-use Moose;
+use Moo;
 
 =head1 NAME
 

--- a/lib/DBIx/Class/Schema/PopulateMore/Inflator/Date.pm
+++ b/lib/DBIx/Class/Schema/PopulateMore/Inflator/Date.pm
@@ -1,6 +1,6 @@
 package DBIx::Class::Schema::PopulateMore::Inflator::Date;
 
-use Moose;
+use Moo;
 use DateTimeX::Easy;
 extends 'DBIx::Class::Schema::PopulateMore::Inflator';
 

--- a/lib/DBIx/Class/Schema/PopulateMore/Inflator/Env.pm
+++ b/lib/DBIx/Class/Schema/PopulateMore/Inflator/Env.pm
@@ -1,6 +1,6 @@
 package DBIx::Class::Schema::PopulateMore::Inflator::Env;
 
-use Moose;
+use Moo;
 extends 'DBIx::Class::Schema::PopulateMore::Inflator';
 
 =head1 NAME

--- a/lib/DBIx/Class/Schema/PopulateMore/Inflator/Find.pm
+++ b/lib/DBIx/Class/Schema/PopulateMore/Inflator/Find.pm
@@ -1,6 +1,6 @@
 package DBIx::Class::Schema::PopulateMore::Inflator::Find;
 
-use Moose;
+use Moo;
 extends 'DBIx::Class::Schema::PopulateMore::Inflator';
 
 =head1 NAME

--- a/lib/DBIx/Class/Schema/PopulateMore/Inflator/Index.pm
+++ b/lib/DBIx/Class/Schema/PopulateMore/Inflator/Index.pm
@@ -1,6 +1,6 @@
 package DBIx::Class::Schema::PopulateMore::Inflator::Index;
 
-use Moose;
+use Moo;
 extends 'DBIx::Class::Schema::PopulateMore::Inflator';
 
 =head1 NAME

--- a/lib/DBIx/Class/Schema/PopulateMore/Visitor.pm
+++ b/lib/DBIx/Class/Schema/PopulateMore/Visitor.pm
@@ -94,7 +94,7 @@ sub callback
     return $self;
 }
 
-=head visit
+=head2 visit
 
 A simple visitor that only expects to perform replacements on values
 

--- a/lib/DBIx/Class/Schema/PopulateMore/Visitor.pm
+++ b/lib/DBIx/Class/Schema/PopulateMore/Visitor.pm
@@ -1,7 +1,10 @@
 package DBIx::Class::Schema::PopulateMore::Visitor;
 
-use Moose;
+use Moo;
 extends 'Data::Visitor';
+use Type::Library -base;
+use Types::Standard -types;
+use namespace::clean;
 
 =head1 NAME
 
@@ -38,7 +41,7 @@ has 'update_callback' => (
     is=>'rw',
     required=>1,
     lazy=>1,
-    isa=>'CodeRef',
+    isa=>CodeRef,
     default=> sub {
         return sub {
             return shift;
@@ -59,7 +62,7 @@ inflate to resultset.  This is the most common usecase.
 has 'match_condition' => (
     is=>'ro',
     required=>1,
-    isa=>'RegexpRef'
+    isa=>RegexpRef,
 );
 
 


### PR DESCRIPTION
I replaced Data::Visitor by adding a simple 'visit' method to Visitor.pm. This is a really simple visitor that iterates through hashes and arrays with value replacement only. This is enough to cover what is needed as far as I can tell.
All Moose deps should now be gone with everything switched to Moo and Type::Tiny.
