### PR TITLE
fix whatis entry in POD

### DIFF
--- a/lib/DBIx/Class/Schema/PopulateMore/Test/Schema.pm
+++ b/lib/DBIx/Class/Schema/PopulateMore/Test/Schema.pm
@@ -7,7 +7,7 @@ use parent 'DBIx::Class::Schema';
 
 =head1 NAME
 
-DBIx::Class::Schema::PopulateMore::Test::Schema; Test Schema
+DBIx::Class::Schema::PopulateMore::Test::Schema - Test Schema
 
 =head1 DESCRIPTION
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to
DBIx-Class-Schema-PopulateMore.
We thought you might be interested in it too.

    Description: fix whatis entry in POD
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2023-01-21
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libdbix-class-schema-populatemore-perl/raw/master/debian/patches/pod.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
